### PR TITLE
fixed issue #52: Add a player to tournament twice leads to exception

### DIFF
--- a/module/Application/src/Application/Controller/TournamentSetupController.php
+++ b/module/Application/src/Application/Controller/TournamentSetupController.php
@@ -13,10 +13,8 @@
 
 namespace Application\Controller;
 
-
-use Application\Model\Entity\AbstractTournament;
+use Application\Model\Entity\Player;
 use Zend\Mvc\Controller\AbstractActionController;
-
 use Application\Form\League as LeagueForm;
 use Application\Form\Tournament as TournamentForm;
 use Application\Form\PlayerToTournament as AddPlayerForm;
@@ -92,6 +90,7 @@ class TournamentSetupController extends AbstractActionController
     {
         $id = $this->params()->fromRoute('id');
 
+        /** @var Tournament $tournament */
         $tournament = $this->tournamentRepository->find($id);
 
         $form = $this->getAddPlayerForm($tournament);
@@ -101,6 +100,8 @@ class TournamentSetupController extends AbstractActionController
             if ($form->isValid()) {
 
                 $playerId = $form->get('player')->getValue();
+
+                /** @var Player $player */
                 $player = $this->playerRepository->find($playerId);
 
                 $tournament->addPlayer($player);

--- a/module/Application/src/Application/Model/Entity/AbstractTournament.php
+++ b/module/Application/src/Application/Model/Entity/AbstractTournament.php
@@ -163,9 +163,15 @@ abstract class AbstractTournament
         }
     }
 
+    /**
+     * @param Player $player
+     */
     public function addPlayer(Player $player)
     {
-        $this->players->add($player);
+        // prevent from adding a player twice
+        if (!$this->players->contains($player)) {
+            $this->players->add($player);
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes #52 by checking if the tournament players already contain the chosen one and ignoring the add in this case. 
